### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.1.0
 Authors@R: c(
     person("Audrey", "Beliveau", , "audrey.beliveau@uwaterloo.ca", role = c("aut", "cre")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut"), comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "ctb", comment = c(ORCID = "0009-0001-4880-5751"))
+    person("Duncan", "Kennedy", role = "ctb", comment = c(ORCID = "0009-0001-4880-5751"))
   )
 Description: Generates data from R or 'JAGS' code for use in simulation
     studies.  The data are returned as an 'nlist::nlists' object and/or


### PR DESCRIPTION
Remove Duncan Kennedy's email from DESCRIPTION.

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)